### PR TITLE
Added return address to SCMessage received from SCClient

### DIFF
--- a/Example_Projects/SwiftCoAPClientExample/SwiftCoAPClientExample/ExampleViewController.swift
+++ b/Example_Projects/SwiftCoAPClientExample/SwiftCoAPClientExample/ExampleViewController.swift
@@ -84,7 +84,7 @@ extension ExampleViewController: SCClientDelegate {
                 payloadstring = String(string)
             }
         }
-        let firstPartString = "Message received with type: \(message.type.shortString())\nwith code: \(message.code.toString()) \nwith id: \(message.messageId)\nPayload: \(payloadstring)"
+        let firstPartString = "Message received from \(message.hostName) with type: \(message.type.shortString())\nwith code: \(message.code.toString()) \nwith id: \(message.messageId)\nPayload: \(payloadstring)"
         var optString = "Options:\n"
         for (key, _) in message.options {
             var optName = "Unknown"

--- a/Example_Projects/SwiftCoAPClientExample/SwiftCoAPClientExample/SCClient.swift
+++ b/Example_Projects/SwiftCoAPClientExample/SwiftCoAPClientExample/SCClient.swift
@@ -357,6 +357,9 @@ extension SCClient: SCCoAPTransportLayerDelegate {
             //Set timestamp
             message.timeStamp = Date()
             
+            //Set return address
+            message.hostName = host
+            
             //Handle Caching, Separate, etc
             if cachingActive && messageInTransmission.code == SCCodeValue(classValue: 0, detailValue: 01) {
                 cachedMessagePairs[messageInTransmission] = SCMessage.copyFromMessage(message)

--- a/SwiftCoAP_Library/SCClient.swift
+++ b/SwiftCoAP_Library/SCClient.swift
@@ -357,6 +357,9 @@ extension SCClient: SCCoAPTransportLayerDelegate {
             //Set timestamp
             message.timeStamp = Date()
             
+            //Set return address
+            message.hostName = host
+            
             //Handle Caching, Separate, etc
             if cachingActive && messageInTransmission.code == SCCodeValue(classValue: 0, detailValue: 01) {
                 cachedMessagePairs[messageInTransmission] = SCMessage.copyFromMessage(message)


### PR DESCRIPTION
I'm doing a project where I use a multicast request to find all clients on the local network. I couldn't find out who the received SCMessage responses were from, so I added a return address to the hostName param